### PR TITLE
[Fix] #57 Invalid UITableViewCell color at CreditViewController

### DIFF
--- a/MovieApp/MovieApp/Presentation/CreditView/View/CreditTableViewCell.swift
+++ b/MovieApp/MovieApp/Presentation/CreditView/View/CreditTableViewCell.swift
@@ -9,11 +9,30 @@ import UIKit
 
 class CreditTableViewCell: UITableViewCell, ReusableCell {
 
-    override func awakeFromNib() {
-        super.awakeFromNib()
-        
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        self.setUpLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setUpLayout() {
         self.backgroundColor = UIColor(named: UIColor.lightBackground)
         self.textLabel?.textColor = .white
+        self.accessoryType = .disclosureIndicator
     }
+}
 
+extension CreditTableViewCell {
+    
+    func setData(_ title: String, _ detail: String) {
+        self.textLabel?.text = title
+        self.detailTextLabel?.text = detail
+    }
+    
+    func setData(_ data: ExternalLink) {
+        self.setData(data.titleText, data.detailText)
+    }
 }

--- a/MovieApp/MovieApp/Presentation/CreditView/View/CreditViewController.swift
+++ b/MovieApp/MovieApp/Presentation/CreditView/View/CreditViewController.swift
@@ -61,10 +61,7 @@ extension CreditViewController: UITableViewDataSource {
             }
 
             let data = ExternalLink.data[indexPath.row]
-            cell.accessoryType = .disclosureIndicator
-            cell.textLabel?.text = data.titleText
-            cell.detailTextLabel?.text = data.detailText
-            
+            cell.setData(data)
             return cell
             
         } else {


### PR DESCRIPTION
### Describe
`CreditTableViewCell` backgroundColor & textColor changing code is not working

### Changes Made
- Move view setting code from awakeFromNib() to custom initializer
- Create setData and setUpLayout method for better code quality

### Screenshots
**AS-IS**
<img src="https://github.com/ChoiysApple/Filmboard/assets/43776784/2d659b22-1876-4549-bf17-09691a9b84dd" width="25%" alt="this was image">

**TO-BE**
<img src="https://github.com/ChoiysApple/Filmboard/assets/43776784/120df159-c92e-4749-80e5-d81c21b9388d" width="25%" alt="this was image">

### Issues Resolved
- #57 
