### PR TITLE
 [Fix] #58 ChartView category change is not working correctly

### DIFF
--- a/MovieApp/MovieApp/Presentation/ChartView/ViewModel/ChartViewModel.swift
+++ b/MovieApp/MovieApp/Presentation/ChartView/ViewModel/ChartViewModel.swift
@@ -27,8 +27,6 @@ class ChartViewModel {
         if currentCategory != category { currentPage = 1 }
         currentCategory = category
         fetchData(category: category)
-        
-        currentPage += 1
     }
     
     func refreshData() {


### PR DESCRIPTION
### Describe
- In Charts View, list content seems like not changing when category is changed but It's reloading
- New list was appended to existing list but it should replace existing list
- Because `currentPage` property is added by 1 whenever category changed, new list is considered as next list

### Changes Made
Remove currentPage adding code from `requestData(category: MovieListCategory)`
```swift
    func requestData(category: MovieListCategory) {
        
        if currentCategory != category { currentPage = 1 }
        currentCategory = category
        fetchData(category: category)
        // current page += 1
    }

```


### Issues Resolved
- #58 
<!-- 
If this pull request addresses or closes any related issues, mention them here. Use the GitHub issue linking format 
(e.g., "Feature #123"). 
-->
